### PR TITLE
Fix optional and required args

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         version:
           - "1.9"
-          - "nightly"
+          - "1.10"
         os:
           - ubuntu-latest
         arch:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,10 +23,10 @@ password = ENV["OPENEO_PASSWORD"]
 c = connect("earthengine.openeo.org", "v1.0", username, password)
 step1 = c.load_collection(
     "COPERNICUS/S2", BoundingBox(west=16.06, south=48.06, east=16.65, north=48.35),
-    ["2020-01-01", "2020-01-31"], ["B10"]
+    ["2020-01-01", "2020-01-31"]; bands = ["B10"]
 )
-step2 = c.reduce_dimension(step1, ProcessGraph("median"), "t", nothing)
-step3 = c.save_result(step2, "GTIFF-ZIP", Dict())
+step2 = c.reduce_dimension(step1, ProcessGraph("median"), "t")
+step3 = c.save_result(step2, "GTIFF")
 path = c.compute_result(step3)
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,15 +22,15 @@ password = ENV["OPENEO_PASSWORD"]
     # test sequential workflow
     step1 = c2.load_collection(
         "COPERNICUS/S2", BoundingBox(west=16.06, south=48.06, east=16.65, north=48.35),
-        ["2020-01-20", "2020-01-30"], ["B10"]
+        ["2020-01-20", "2020-01-30"]; bands=["B10"]
     )
     @test step1.id == "load_collection_tQ79zrFEGi8="
     @test step1.process_id == "load_collection"
     @test Set(keys(step1.arguments)) == Set([:bands, :id, :spatial_extent, :temporal_extent])
     @test step1.arguments[:bands] == ["B10"]
 
-    step2 = c2.reduce_dimension(step1, ProcessGraph("median"), "t", nothing)
-    step3 = c2.save_result(step2, "JPEG", Dict())
+    step2 = c2.reduce_dimension(step1, ProcessGraph("median"), "t")
+    step3 = c2.save_result(step2, "JPEG")
     result = c2.compute_result(step3)
     @test result == "out.jpeg"
 


### PR DESCRIPTION
Some functions e.g. `sar_backscatter` require to not set some arguments on some data collections. This PR maps required opEO process arguments to positional julia function arguments.