### PR TITLE
Add lambda functions to create `ProcessGraph`

### DIFF
--- a/src/OpenEOClient.jl
+++ b/src/OpenEOClient.jl
@@ -15,6 +15,7 @@ export
     compute_result,
     connect,
     DataCube,
+    value,
     describe_collection,
     to_band,
     list_collections,

--- a/src/Processes.jl
+++ b/src/Processes.jl
@@ -76,6 +76,11 @@ struct ProcessCallParameter <: AbstractProcessCall
     from_parameter::String
 end
 
+"""
+Placeholder to define process graphs e.g. lambda functions
+"""
+const value = ProcessCallParameter("value")
+
 mutable struct ProcessCall <: AbstractProcessCall
     const id::String
     const process_id::String


### PR DESCRIPTION
This PR adds support to create a `ProcessGraph` using lambda like syntax.
This is a generic to the functions defined for a `DataCube`.
We use `ProcessGraph(42 * log(value,3))` instead of `x -> 42 * log(x, 3)`, because  most Julia fucntions are not supported by openEO.

```julia
using OpenEOClient
using ArchGDAL
using YAXArrays
using GLMakie

con = connect("openeo.dataspace.copernicus.eu/openeo", "", OpenEOClient.oidc_auth)
s1 = con.load_collection(
    "SENTINEL1_GRD",
    BoundingBox(west=11.293602, south=46.460163, east=11.382866, north=46.514768),
    ["2021-01-01", "2021-01-08"];
    bands = ["VV", "VH"],
    properties = Dict("sat:orbit_state" => ProcessGraph(value == :ASCENDING))
)
s2 = con.sar_backscatter(s1; coefficient="sigma0-ellipsoid", elevation_model="COPERNICUS_30")
s3 = con.apply(s2, ProcessGraph(10 * log(value, 10)))
s4 = con.save_result(s3, "GTiff")
path = con.compute_result(s3)
ds = open_dataset(path) 
plot(ds.Gray)
``` 

[Example taken from python client](https://github.com/eu-cdse/notebook-samples/blob/main/openeo/Radar_ARD.ipynb)